### PR TITLE
new nss_aws_login script

### DIFF
--- a/aws/nss_aws_login
+++ b/aws/nss_aws_login
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+#
+# Convenience script for logging out then logging in also
+# getting temporary AWS credentials from the command line
+# and setting them to be the 'default' profile.
+# https://aws.amazon.com/premiumsupport/knowledge-center/sso-temporary-credentials/
+#
+# IMPORTANT NOTES:
+# - This assumes that the first profile in your AWS credentials file is the
+# 'default' one, and will make updates to it accordingly. Specifically, it will
+# overwrite lines 2 (key_id), 3 (secret), and 4 (token).
+# - If you have multiple profiles in the file, make sure they don't start
+# until line 5.
+# - If the credentials file exists, it will make a single backup copy. If
+# the credentials file does NOT exist, it will create an empty one.
+#
+
+profile_name="$1"
+if [ -z "$profile_name" ]; then
+  echo "usage: $(basename $0) PROFILE_NAME"
+  exit 1
+fi
+
+if ! aws configure list-profiles | grep $profile_name >/dev/null; then
+  echo "ERROR: Invalid AWS PROFILE_NAME specified"
+  exit 1
+fi
+
+echo "## Performing AWS Login with the profile $profile_name."
+echo "##"
+
+echo "## Step 1: aws sso logout"
+aws sso logout
+
+echo "## Step 2: aws sso login --profile $profile_name"
+aws sso login --profile $profile_name
+
+echo
+echo "## Step 3: make $profile_name the default profile"
+
+ssh_cache_file=$(find ~/.aws/sso/cache -maxdepth 1 -type f -name "[0-9]*.json" -exec grep -l accessToken {} \;)
+if [ -z "$ssh_cache_file" ]; then
+  echo "ERROR: Cannot find SSO file - have you run 'aws sso login --profile $profile_name' first?"
+  exit 1
+fi
+
+CREDS=~/.aws/credentials
+if [ ! -e $CREDS ]; then
+  echo "## Creating an empty credentials file"
+  mkdir -p $(dirname $CREDS)
+  touch $CREDS
+  chmod 600 $CREDS
+  echo "[default]" > $CREDS
+  echo "aws_access_key_id=tmp" >> $CREDS
+  echo "aws_secret_access_key=tmp" >> $CREDS
+  echo "aws_session_token=tmp" >> $CREDS
+else
+  echo "## Making backup copy of existing credentials file"
+  cp $CREDS ${CREDS}.bak
+fi
+# set -xv   # this line will enable debug
+echo "## Getting Account and Role Name from config"
+account_id=$(aws configure get sso_account_id --profile $profile_name)
+role_name=$(aws configure get sso_role_name --profile $profile_name)
+region=$(aws configure get region --profile $profile_name)
+
+# set the default region in config
+aws configure set region $region
+
+token=$(cat $ssh_cache_file | jq -r '.accessToken')
+
+# if credentials have expired (e.g. overnight) this commmand will fail, thus the check here
+echo "## Getting SSO role credentials"
+
+credentials=$(aws sso get-role-credentials --role-name $role_name --account-id $account_id --access-token $token --region $region)
+if [ -z "$credentials" ]; then
+  echo
+  echo "ERROR: Have you run 'aws sso login --profile $profile_name' first?"
+  exit 1
+fi
+
+# set +xv  # this line will enable debug
+# at this point we should have everything we need and can get the variables
+access_key=$(echo $credentials | jq -r '.roleCredentials.accessKeyId')
+access_secret=$(echo $credentials | jq -r '.roleCredentials.secretAccessKey')
+session_token=$(echo $credentials | jq -r '.roleCredentials.sessionToken')
+
+# awk magic to indiscriminately replace lines 2-4 in the credentials file
+cat $CREDS | \
+  awk -v access_key=$access_key '{ if(NR==2) print "aws_access_key_id=" access_key; else print $0}' | \
+  awk -v access_secret=$access_secret '{ if(NR==3) print "aws_secret_access_key=" access_secret; else print $0}' | \
+  awk -v session_token=$session_token '{if(NR==4) print "aws_session_token=" session_token; else print $0}' > ${CREDS}.new
+mv ${CREDS}.new $CREDS
+
+echo "## Validating AWS Identity with the following:"
+echo "Account ID : $account_id"
+echo "Profile    : $profile_name"
+echo "SSO Role   : $role_name"
+echo
+aws --no-cli-pager sts get-caller-identity

--- a/aws/nss_aws_login
+++ b/aws/nss_aws_login
@@ -41,7 +41,7 @@ echo "## Step 3: make $profile_name the default profile"
 
 ssh_cache_file=$(find ~/.aws/sso/cache -maxdepth 1 -type f -name "[0-9]*.json" -exec grep -l accessToken {} \;)
 if [ -z "$ssh_cache_file" ]; then
-  echo "ERROR: Cannot find SSO file - have you run 'aws sso login --profile $profile_name' first?"
+  echo "ERROR: Cannot find SSO file."
   exit 1
 fi
 
@@ -70,13 +70,11 @@ aws configure set region $region
 
 token=$(cat $ssh_cache_file | jq -r '.accessToken')
 
-# if credentials have expired (e.g. overnight) this commmand will fail, thus the check here
 echo "## Getting SSO role credentials"
-
-credentials=$(aws sso get-role-credentials --role-name $role_name --account-id $account_id --access-token $token --region $region)
+credentials=$(aws sso get-role-credentials --role-name $role_name --account-id $account_id --access-token $token)
 if [ -z "$credentials" ]; then
   echo
-  echo "ERROR: Have you run 'aws sso login --profile $profile_name' first?"
+  echo "ERROR: Unable to get SSO role credentials."
   exit 1
 fi
 


### PR DESCRIPTION
This change-set introduces a new `nss_aws_login` bash script. 

This new script combines the functionality of the old bash function `nss_aws_login` and `get-default-credentials.sh` bash script.

For context ( readme on how to install the `nss_aws_login` function https://gist.github.com/cpenner461/d92556edbe4a5655a3d551932fbdd361)

The idea is to instruct students to download this script to their ~/bin directories and use it as a one step process to login and 
set their default aws profiles. It works with the newest aws cli version `aws-cli/2.12.3 Python/3.11.4 Darwin/21.6.0 exe/x86_64 prompt/off` 

There are some changes in how this script works from the old one and I called this out below.

Tested via the aws cli as well as deployed and ran the unit 3 project. 

